### PR TITLE
Add cross-repo clone support with rm -rf cleanup

### DIFF
--- a/.github/workflows/build-test-release-java11.yml
+++ b/.github/workflows/build-test-release-java11.yml
@@ -243,6 +243,7 @@ jobs:
             repo=$(echo $repo_branch | cut -d@ -f1)
             branch=$(echo $repo_branch | cut -d@ -f2)
             name=$(basename $repo)
+            rm -rf ${name}
             if [ "$branch" != "$repo_branch" ]; then
               git clone -b $branch https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${repo}.git ${name}
             else

--- a/.github/workflows/build-test-release_dcompose-java11.yml
+++ b/.github/workflows/build-test-release_dcompose-java11.yml
@@ -235,6 +235,7 @@ jobs:
             repo=$(echo $repo_branch | cut -d@ -f1)
             branch=$(echo $repo_branch | cut -d@ -f2)
             name=$(basename $repo)
+            rm -rf ${name}
             if [ "$branch" != "$repo_branch" ]; then
               git clone -b $branch https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${repo}.git ${name}
             else


### PR DESCRIPTION
Adds GitHub App token generation and cross-repo clone support to build-test-release-java11.yml and build-test-release_dcompose-java11.yml.

Changes:
- Added CORE_APP_ID and CORE_APP_PRIVATE_KEY secrets
- Added createAppToken (boolean) and reposToClone (JSON array) inputs
- Added steps to generate GitHub App token and clone dependency repos into current directory
- Added rm -rf cleanup before clone to ensure fresh checkout